### PR TITLE
feat(hierarki): funksjon for å liste opp alle forfedre

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-const natursystem = require("./NA-metoder");
-const art = require("./AR-metoder");
-const administrativtOmråde = require("./AO-metoder");
-const miljøvariabel = require("./MI-metoder");
-const fremmedArt = require("./FA-metoder");
-const verneområde = require("./VV-metoder");
-const nivåer = require("./nivåer");
+const natursystem = require("./NA-metoder")
+const art = require("./AR-metoder")
+const administrativtOmråde = require("./AO-metoder")
+const miljøvariabel = require("./MI-metoder")
+const fremmedArt = require("./FA-metoder")
+const verneområde = require("./VV-metoder")
+const nivåer = require("./nivåer")
 
 const typesystem = {
   art: art,
@@ -18,48 +18,78 @@ const typesystem = {
   nivåer: nivåer,
 
   hentNivaa(kode) {
-    const frags = this.splittKode(kode);
-    const prefiks = frags[0];
-    if (!(prefiks in this.nivåer)) return [];
-    const grein = this.nivåer[prefiks];
-    return grein.slice(0, frags.length).reverse();
-  },
-
-  // Deler opp koden i ett array av segmenter, 1 for hvert nivå
-  // i.e. 'NA_T44-E-1 => ['NA','T','44','E','1']
-  splittKode: function(kode) {
-    let segments = kode.match(/[a-zA-Z]+|[0-9]+/g);
-    return segments || [];
+    const frags = this.splittKode(kode)
+    const prefiks = frags[0]
+    if (!(prefiks in this.nivåer)) return []
+    const grein = this.nivåer[prefiks]
+    return grein.slice(0, frags.length).reverse()
   },
 
   // Deler opp koden i ett array av segmenter, 1 for hvert nivå
   // tar hensyn til målestokk for NA
   // i.e. 'NA_T44-E-1 => ['NA','T','44','E-1']
-  splittKodeMalestokk: function(kode) {
+  splittKode: function(kode) {
     if (kode && kode.toUpperCase().indexOf("NA") === 0) {
-      let segments = kode.match(/([a-eA-E]-[0-9]+)|[a-zA-Z]+|[0-9]+/g);
-      return segments || [];
+      let segments = kode.match(/([a-eA-E]-[0-9]+)|[a-zA-Z]+|[0-9]+/g)
+      return segments || []
     }
-    let segments = kode.match(/[a-zA-Z]+|[0-9]+/g);
-    return segments || [];
+    let segments = kode.match(/[a-zA-Z]+|[0-9]+/g)
+    return segments || []
   },
+
+  erSkille: function(c, p) {
+    if ("_-".indexOf(c) >= 0) return true
+    //if ("_-".indexOf(p) >= 0) return false
+    const digits = "0123456789"
+    const cdig = digits.indexOf(c) >= 0
+    const pdig = digits.indexOf(p) >= 0
+    return cdig !== pdig
+  },
+
+  forfedre: function(kode) {
+    const stack = []
+    let prefix = ""
+    let prev = "A"
+    for (let i = 0; i < kode.length; i++) {
+      const c = kode[i]
+      if (this.erSkille(c, prev)) stack.push(prefix)
+      prefix += c
+      prev = c
+    }
+    stack.push(prefix)
+    return stack
+  },
+
+  forelder: function(kode) {
+    const segments = this.splittKode(kode)
+    if (segments.length <= 0) return null
+    const trimOff = segments[segments.length - 1].length
+    let end = kode.length - trimOff
+    console.log(end)
+    console.log(kode.substring(0, end))
+    if (end > 0 && "-_".indexOf(kode[end - 1]) >= 0) end -= 1
+    console.log(end)
+    console.log(kode.substring(0, end))
+    return kode.substring(0, end)
+  },
+
   // Erstatter tegn som ikke kan brukes i en url
   medGyldigeTegn: function(s) {
     const r = s
       .split("")
       .map(c => {
-        const lc = c.toLowerCase();
-        if ("_,./()[] ".indexOf(c) >= 0) return "_";
-        if ("abcdefghijklmnopqrstuvxyzæøå0123456789".indexOf(lc) >= 0) return c;
-        return "";
+        const lc = c.toLowerCase()
+        if ("_,./()[] ".indexOf(c) >= 0) return "_"
+        if ("abcdefghijklmnopqrstuvxyzæøå0123456789".indexOf(lc) >= 0) return c
+        return ""
       })
-      .join("");
-    return r;
+      .join("")
+    return r
   },
 
   capitalizeTittel: function(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
+    return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase()
   }
-};
+}
 
-module.exports = typesystem;
+module.exports = typesystem

--- a/test/natursystem.js
+++ b/test/natursystem.js
@@ -1,23 +1,23 @@
-var assert = require("assert");
-var natursystem = require("../src/NA-metoder");
+var assert = require("assert")
+var natursystem = require("../src/NA-metoder")
 
 describe("Natursystem", function() {
   it("hovedtype", function() {
-    assert.equal(natursystem.slåOppHovedtype("NA_T44-E-1"), "NA_T44");
-  });
+    assert.equal(natursystem.slåOppHovedtype("NA_T44-E-1"), "NA_T44")
+  })
   it("T44-E-1 er ikke grunntype", function() {
-    assert.equal(natursystem.erGrunntype("NA_T44-E-1"), false);
-  });
+    assert.equal(natursystem.erGrunntype("NA_T44-E-1"), false)
+  })
   it("T44-1 er grunntype", function() {
-    assert.equal(natursystem.erGrunntype("NA_T44-1"), true);
-  });
+    assert.equal(natursystem.erGrunntype("NA_T44-1"), true)
+  })
   it("T44-1 erHøyereKartleggingsnivå: nei", function() {
-    assert.equal(natursystem.erHøyereKartleggingsnivå("NA_T44-1"), false);
-  });
+    assert.equal(natursystem.erHøyereKartleggingsnivå("NA_T44-1"), false)
+  })
   it("T44-A-1 erHøyereKartleggingsnivå: nei", function() {
-    assert.equal(natursystem.erHøyereKartleggingsnivå("NA_T44-A-1"), false);
-  });
+    assert.equal(natursystem.erHøyereKartleggingsnivå("NA_T44-A-1"), false)
+  })
   it("T44-B-1 erHøyereKartleggingsnivå: ja", function() {
-    assert.equal(natursystem.erHøyereKartleggingsnivå("NA_T44-B-1"), true);
-  });
-});
+    assert.equal(natursystem.erHøyereKartleggingsnivå("NA_T44-B-1"), true)
+  })
+})

--- a/test/typesystem.js
+++ b/test/typesystem.js
@@ -1,33 +1,39 @@
-var assert = require("assert");
-var typesystem = require("../src/index");
+var assert = require("assert")
+var typesystem = require("../src/index")
 
 describe("typesystem", function() {
   it("splitt T44-E-1", function() {
-    assert.equal(typesystem.splittKode("NA_T44-E-1").join("/"), "NA/T/44/E/1");
-  });
+    assert.equal(typesystem.splittKode("NA_T44-E-1").join("/"), "NA/T/44/E-1")
+  })
   it("splitt BS_1_AG_A_0", function() {
-    assert.equal(typesystem.splittKode("BS_1_AG_A_0").join("/"), "BS/1/AG/A/0");
-  });
-  it("splitt T44-E-1", function() {
-    assert.equal(
-      typesystem.splittKodeMalestokk("NA_T44-E-1").join("/"),
-      "NA/T/44/E-1"
-    );
-  });
+    assert.equal(typesystem.splittKode("BS_1_AG_A_0").join("/"), "BS/1/AG/A/0")
+  })
+  it("forelder T44", function() {
+    assert.equal(typesystem.forelder("NA_T44"), "NA_T")
+  })
+  it("forelder T44-E1-C2", function() {
+    assert.equal(typesystem.forelder("NA_T44-E-2"), "NA_T44")
+  })
 
   it("Davvisámegiella med gyldige tegn", function() {
-    assert.equal(
-      typesystem.medGyldigeTegn("Davvisámegiella"),
-      "Davvismegiella"
-    );
-  });
+    assert.equal(typesystem.medGyldigeTegn("Davvisámegiella"), "Davvismegiella")
+  })
   it("Kapitaliserer canis lupus", function() {
-    assert.equal(typesystem.capitalizeTittel("cAnis LuPus"), "Canis lupus");
-  });
+    assert.equal(typesystem.capitalizeTittel("cAnis LuPus"), "Canis lupus")
+  })
   it("Nivå for åker", function() {
     assert.equal(
       typesystem.hentNivaa("NA_T44").join(","),
       "hovedtype,hovedtypegruppe,naturmangfold"
-    );
-  });
-});
+    )
+  })
+  it("NA foreldre", function() {
+    assert.equal(typesystem.forfedre("NA").join(","), "NA")
+  })
+  it("T44-B-1 foreldre", function() {
+    assert.equal(
+      typesystem.forfedre("NA_T44-B-1").join(","),
+      "NA,NA_T,NA_T44,NA_T44-B,NA_T44-B-,NA_T44-B-1"
+    )
+  })
+})


### PR DESCRIPTION
Splitter opp en kode og lager en liste med alle forfedrene. ie. NA_T44 => ['NA','NA_T','NA_T44']

BREAKING CHANGE: fjernet splittKodeMalestokk