### PR TITLE
fix(nivå): Unngå at nivå heter typeinndeling: typeinndeling

### DIFF
--- a/src/nivåer.json
+++ b/src/nivåer.json
@@ -42,7 +42,7 @@
       },
       "nivå": ["Landskap"],
       "Typeinndeling": {
-        "nivå": ["Typeinndeling", "Hovedtypegruppe", "Hovedtype", "Grunntype"]
+        "nivå": ["Landskapstype", "Hovedtypegruppe", "Hovedtype", "Grunntype"]
       }
     },
     "Natursystem": {
@@ -59,7 +59,7 @@
       },
       "Typeinndeling": {
         "nivå": [
-          "Typeinndeling",
+          "Naturtype",
           "Hovedtypegruppe",
           "Hovedtype",
           "Kartleggingsenhet 1:20000",

--- a/test/typesystem.js
+++ b/test/typesystem.js
@@ -43,7 +43,7 @@ describe("typesystem", function() {
           "Natur_i_Norge/Natursystem/Typeinndeling/Fastmarkssystemer/Åker"
         )
         .join(","),
-      "Hovedtype,Hovedtypegruppe,Typeinndeling,Natursystem,Natur i Norge"
+      "Hovedtype,Hovedtypegruppe,Naturtype,Natursystem,Natur i Norge"
     );
   });
   it("Nivå for katalog", function() {
@@ -114,7 +114,7 @@ describe("typesystem", function() {
           "Natur_i_Norge/Natursystem/Typeinndeling/Snø-_og_issystemer/Snø-"
         )
         .join(","),
-      "Hovedtype,Hovedtypegruppe,Typeinndeling,Natursystem,Natur i Norge"
+      "Hovedtype,Hovedtypegruppe,Naturtype,Natursystem,Natur i Norge"
     );
   });
 });


### PR DESCRIPTION
Bruker naturtype og landskapstype som betegnelse på nivået